### PR TITLE
Fix effect position offset

### DIFF
--- a/src/Nemo.js
+++ b/src/Nemo.js
@@ -241,11 +241,12 @@ class Nemo {
             ctx.stroke();
         }
 
-        // 네모가 그려진 후 이펙트를 그려 상위에 보이도록 한다
+        ctx.restore();
+
+        // 네모가 그려진 후 이펙트를 전역 좌표계에서 그려 상위에 보이도록 한다
         this.platforms.forEach(p => {
             if (p.drawEffects) p.drawEffects(ctx);
         });
-        ctx.restore();
     }
 }
 


### PR DESCRIPTION
## Summary
- restore canvas transform before drawing effects so muzzle flash and bullet hits appear at correct location

## Testing
- `node --check src/Nemo.js`
- `node --check src/Platform.js`
- `node --check src/MuzzleFlash.js`
- `node --check src/HitEffect.js`
- `node --check src/Bullet.js`


------
https://chatgpt.com/codex/tasks/task_e_68774d5db74c833283590210274418be